### PR TITLE
Expose host services

### DIFF
--- a/Microsoft.AspNetCore.Components.Testing/TestHost.cs
+++ b/Microsoft.AspNetCore.Components.Testing/TestHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Components.Testing
             });
         }
 
-        public IServiceProvider serviceProvider { get { return _serviceCollection.BuildServiceProvider(); } }
+        public IServiceProvider Services { get { return _serviceCollection.BuildServiceProvider(); } }
 
         public void AddService<T>(T implementation)
             => AddService<T, T>(implementation);

--- a/Microsoft.AspNetCore.Components.Testing/TestHost.cs
+++ b/Microsoft.AspNetCore.Components.Testing/TestHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNetCore.Components.Testing
             });
         }
 
-        public ServiceCollection serviceCollection { get { return _serviceCollection; } }
+        public IServiceProvider serviceProvider { get { return _serviceCollection.BuildServiceProvider(); } }
 
         public void AddService<T>(T implementation)
             => AddService<T, T>(implementation);

--- a/Microsoft.AspNetCore.Components.Testing/TestHost.cs
+++ b/Microsoft.AspNetCore.Components.Testing/TestHost.cs
@@ -23,6 +23,8 @@ namespace Microsoft.AspNetCore.Components.Testing
             });
         }
 
+        public ServiceCollection serviceCollection { get { return _serviceCollection; } }
+
         public void AddService<T>(T implementation)
             => AddService<T, T>(implementation);
 


### PR DESCRIPTION
Exposed the ServiceProvider in TestHost.
Some tests may require access to the host's services.